### PR TITLE
Add switch number to address for switch settings

### DIFF
--- a/ficwww.py
+++ b/ficwww.py
@@ -364,7 +364,7 @@ def rest_switch_post():
                         raise KeyError('slot {0:s} is not found'.format(sout_key))
 
                     addr_lo = sout
-                    addr = (addr_hi << 8 | addr_lo)
+                    addr = (addr_hi << 8 | on << 6 | addr_lo)
                     tbl_tmp.append((addr, _table[nout_key][pout_key][sout_key]))    # Set to internal table
 
         # Set onmemory internal table (for reference cache)


### PR DESCRIPTION
@nyacom 
#11 の対応PRです。
[ふんがさんのラズパイのI/Oに関するドキュメント](https://drive.google.com/file/d/1gcpUjJUKIRUYDUbL61wwDbwOS3tcJl00/view?usp=sharing)のslot tableのアドレスフォーマットに基づいて7,6bit目に設定するswitchの番号(tableのjsonファイルではoutputXに対応する値)を入れることで各スイッチに個別の設定をすることが可能となります。このPRのコードでficwwwを起動しスイッチの設定をしたところsw1を使って3枚のボードで問題なく通信をしパケットカウンターの値も想定通りでした。

複数スイッチへの対応ということで、outputというプロパティ名だと少しわかりづらさがあるのでswitchというプロパティ名に変更するほうが使いやすいかもしれません。テーブルのjsonのフォーマットも修正が必要ですが、もし問題なければこのブランチで引き続きそこも修正してしまおうと思うのですがいかがでしょうか？